### PR TITLE
Workaround for lightbox

### DIFF
--- a/neoteroi/mkdocs/cards/html.py
+++ b/neoteroi/mkdocs/cards/html.py
@@ -85,7 +85,7 @@ class CardsHTMLBuilder:
 
         if self.use_image_tags:
             #If the card is a link, mark the image to be skipped by glightbox.
-            skip = item.url != ""
+            skip = isinstance(item.url, str) and item.url != ""
             build_image_html(
                 etree.SubElement(
                     wrapper_element, "div", {"class": "nt-card-image tags"}

--- a/neoteroi/mkdocs/cards/html.py
+++ b/neoteroi/mkdocs/cards/html.py
@@ -84,11 +84,13 @@ class CardsHTMLBuilder:
             return
 
         if self.use_image_tags:
+            #If the card is a link, mark the image to be skipped by glightbox.
+            skip = item.url != ""
             build_image_html(
                 etree.SubElement(
                     wrapper_element, "div", {"class": "nt-card-image tags"}
                 ),
-                item.image,
+                item.image, skip_glightbox=skip
             )
         else:
             etree.SubElement(

--- a/neoteroi/mkdocs/markdown/images.py
+++ b/neoteroi/mkdocs/markdown/images.py
@@ -36,8 +36,13 @@ class Image:
         return props
 
 
-def build_image_html(parent, image: Image):
-    etree.SubElement(parent, "img", image.get_props())
+def build_image_html(parent, image: Image, skip_glightbox: bool = False):
+    props = image.get_props()
+    # adds the "skip-lightbox" class to the image
+    if skip_glightbox:
+        props["class"] = "skip-lightbox"
+
+    etree.SubElement(parent, "img", props)
 
 
 def build_icon_html(parent, icon):

--- a/neoteroi/mkdocs/markdown/images.py
+++ b/neoteroi/mkdocs/markdown/images.py
@@ -40,7 +40,7 @@ def build_image_html(parent, image: Image, skip_glightbox: bool = False):
     props = image.get_props()
     # adds the "skip-lightbox" class to the image
     if skip_glightbox:
-        props["class"] = "skip-lightbox"
+        props["class"] = "off-glb"
 
     etree.SubElement(parent, "img", props)
 


### PR DESCRIPTION
Lightbox will handily ruin any cards that have a `url` attribute. It moves the link from a parent element to an empty sibling; marking any child images with the `skip-lightbox` class fixes this.

markdown/image.py: I added a variable to the `build_image_html` method to add this class to the image. It defaults to `False`, so it won't break existing code.

cards/html.py: If the card has a URL, each `build_image_html` call asks for the `skip-lightbox` class in the html.

Hope this is helpful!

Edit: I fixed an issue where `item.url` being `None` wasn't caught.