### PR TITLE
Add mkdocs.yml JSON schema for markdown extensions

### DIFF
--- a/docs/extensions-schema.json
+++ b/docs/extensions-schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "title": "Neoteroi markdown extensions",
+    "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins",
+    "oneOf": [
+      {
+        "title": "Cards – Neoteroi Markdown",
+        "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/cards/",
+        "const": "neoteroi.cards"
+      },
+      {
+        "title": "Timeline – Neoteroi Markdown",
+        "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/timeline/",
+        "const": "neoteroi.timeline"
+      },
+      {
+        "title": "Gantt – Neoteroi Markdown",
+        "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/gantt/",
+        "const": "neoteroi.projects"
+      },
+      {
+        "title": "Spantable – Neoteroi Markdown",
+        "markdownDescription": "https://www.neoteroi.dev/mkdocs-plugins/spantable/",
+        "const": "neoteroi.spantable"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
This allows the Markdown extensions provided by this MkDocs plugin to be included in the [`mkdocs.yml` JSON schema definition](https://squidfunk.github.io/mkdocs-material/creating-your-site/#configuration) maintained by the developers of `mkdocs-material`.

See https://github.com/squidfunk/mkdocs-material/pull/6381 and https://github.com/squidfunk/mkdocs-material/issues/6378.