### PR TITLE
Show event description

### DIFF
--- a/neoteroi/mkdocs/projects/gantt/html.py
+++ b/neoteroi/mkdocs/projects/gantt/html.py
@@ -419,6 +419,15 @@ class GanttHTMLBuilder:
         if event.icon:
             build_icon_html(dot_element, event.icon)
 
+        if event.description:
+            try:
+                des = etree.fromstring(event.description)
+            except etree.ParseError:
+                des = etree.fromstring(f"<span>{event.description}</span>")
+            
+            des.set("class", f"description {des.get('class') or ''}")
+            dot_element.append(des)
+
     def _calc_time_left(self, time: Union[date, datetime]) -> float:
         delta = (
             time


### PR DESCRIPTION
Only a suggestion..
I think the description property could be better used to display additional information in events (or even activities).
The proposed change is only a quick and possibly dirty way to render the description as html or as text in a span. It allows me abuse it a bit:

```markdown
<style>
  .months {
    opacity: 0
  }

  .nt-plan-group.nt-group-0 .nt-plan-group-summary {
    opacity: 0
  }

  .nt-timeline-dot .description {
    position: absolute;
    left: 120%;
    font-size: smaller;
    filter: drop-shadow(0 1px 1px black);

    top: 50%;
    transform: translateY(-50%);
  }
</style>

::gantt:: no-years no-quarters no-days month-width=800

- title: ""
  events:
    - title: Month Begin
      time: 2024-01-01
      icon: ":material-calendar-start:"
      description: Month Begin
    - title: Patch Tuesday
      time: 2024-01-09
      icon: ":material-rocket-launch:"
      description: Patch Tuesday
    - title: Month End
      time: 2024-01-31
      icon: ":material-calendar-end:"
      description: "<span style='left: unset; right: 120%'>Month End</span>"
- title: Server Group A
  activities:
    - title: Pre-prod (SAT-TUE)
      start: 2024-01-13
      lasts: 4 days
    - title: Prod (SAT-SUN)
      start: 2024-01-20
      lasts: 2 days
- title: Server Group B
  activities:
    - title: Pre-prod (TUE)
      start: 2024-01-16
      lasts: 1 day
    - title: Prod (SAT-SUN)
      start: 2024-01-20
      lasts: 2 days

::/gantt::
```

which results in:

![image](https://github.com/Neoteroi/mkdocs-plugins/assets/15975872/c808c381-fc9d-442c-99e8-2011f9ebfa32)
