### PR TITLE
chore: switch mkdocs dependency to mkdocs-ng

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ keywords = [
 ]
 dependencies = [
     "essentials-openapi>=1.3.0",
-    "mkdocs",
+    "mkdocs-ng",
     "httpx",
     "click",
     "Jinja2",


### PR DESCRIPTION
Hi, this is a small PR to suggest switching the `mkdocs` dependency to `mkdocs-ng`.

The `mkdocs` package on PyPI is currently unmaintained — see [Is MkDocs still maintained?](https://github.com/mkdocs/mkdocs/discussions/4010) and [The Slow Collapse of MkDocs](https://fpgmaas.com/blog/collapse-of-mkdocs/) for context.

[`mkdocs-ng`](https://pypi.org/project/mkdocs-ng/) is a community-maintained fork that:
- Keeps the same `mkdocs` CLI — no changes for end users
- Adds Python 3.13 / 3.14 support
- Includes bug fixes and active development
- One-line drop-in replacement

```diff
- mkdocs
+ mkdocs-ng
```

No obligation — just sharing in case it's helpful. Thanks!